### PR TITLE
[J-007] Redirect 요청 컨텍스트(IP, User-Agent) 모델링

### DIFF
--- a/src/main/kotlin/com/example/jaebitly/application/RedirectEventPublisher.kt
+++ b/src/main/kotlin/com/example/jaebitly/application/RedirectEventPublisher.kt
@@ -1,6 +1,5 @@
 package com.example.jaebitly.application
 
-import com.example.jaebitly.domain.ShortKey
 import com.example.jaebitly.domain.event.RedirectEvent
 
 interface RedirectEventPublisher {

--- a/src/main/kotlin/com/example/jaebitly/application/RedirectUseCase.kt
+++ b/src/main/kotlin/com/example/jaebitly/application/RedirectUseCase.kt
@@ -1,25 +1,35 @@
 package com.example.jaebitly.application
 
+import com.example.jaebitly.domain.RedirectRequestContext
 import com.example.jaebitly.domain.ShortKey
 import com.example.jaebitly.domain.event.RedirectEvent
 import org.springframework.stereotype.Component
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.event
 import java.time.Instant
-import java.time.LocalDateTime
 
 @Component
 class RedirectUseCase(
     private val linkRepository: LinkRepository,
     private val eventPublisher: RedirectEventPublisher,
 ) {
-    fun execute(shortKey: String): RedirectResult {
+    fun execute(
+        shortKey: String,
+        context: RedirectRequestContext,
+    ): RedirectResult {
         val key = ShortKey(shortKey)
 
         val originalUrl =
             linkRepository.findByShortKey(shortKey = key)
                 ?: throw ShortLinkNotFoundException()
 
-        eventPublisher.publish(event = RedirectEvent(shortKey = key.value, occurredAt = Instant.now()))
+        eventPublisher.publish(
+            event =
+                RedirectEvent(
+                    shortKey = key.value,
+                    occurredAt = Instant.now(),
+                    ip = context.ip,
+                    userAgent = context.userAgent,
+                ),
+        )
 
         return RedirectResult(
             targetUrl = originalUrl.value,

--- a/src/main/kotlin/com/example/jaebitly/controller/RedirectController.kt
+++ b/src/main/kotlin/com/example/jaebitly/controller/RedirectController.kt
@@ -1,11 +1,14 @@
 package com.example.jaebitly.controller
 
 import com.example.jaebitly.application.RedirectUseCase
+import com.example.jaebitly.domain.RedirectRequestContext
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -15,8 +18,23 @@ class RedirectController(
     @GetMapping("/{shortKey}")
     fun redirect(
         @PathVariable("shortKey") shortKey: String,
+        request: HttpServletRequest,
     ): ResponseEntity<Void> {
-        val result = redirectUseCase.execute(shortKey)
+        val ip =
+            request
+                .getHeader("X-Forwarded-For")
+                ?.split(",")
+                ?.first()
+                ?.trim()
+                ?: request.remoteAddr
+        val agent = request.getHeader("User-Agent")
+        val context =
+            RedirectRequestContext(
+                ip = ip,
+                userAgent = agent,
+            )
+
+        val result = redirectUseCase.execute(shortKey = shortKey, context = context)
 
         return ResponseEntity
             .status(HttpStatus.FOUND)

--- a/src/main/kotlin/com/example/jaebitly/domain/RedirectRequestContext.kt
+++ b/src/main/kotlin/com/example/jaebitly/domain/RedirectRequestContext.kt
@@ -1,0 +1,6 @@
+package com.example.jaebitly.domain
+
+data class RedirectRequestContext(
+    val ip: String?,
+    val userAgent: String?,
+)

--- a/src/main/kotlin/com/example/jaebitly/domain/event/RedirectEvent.kt
+++ b/src/main/kotlin/com/example/jaebitly/domain/event/RedirectEvent.kt
@@ -5,4 +5,6 @@ import java.time.Instant
 data class RedirectEvent(
     val shortKey: String,
     val occurredAt: Instant,
+    val ip: String?,
+    val userAgent: String?,
 )


### PR DESCRIPTION
## 관련 이슈
- J-007

## 작업 내용
리다이렉트 요청 시 IP, User-Agent 정보를 이벤트로 기록할 수 있도록 구조를 확장

## 변경 사항
- Redirect 요청 컨텍스트(IP, User-Agent) 모델 추가
- Controller에서 요청 컨텍스트 추출 후 UseCase로 전달
- RedirectEvent에 컨텍스트 정보 포함

## 확인 사항
- [x] 로컬 실행 및 리다이렉트 동작 확인
- [x] 기존 기능 영향 없음

## 비고
요청 컨텍스트 해석(국가, 브라우저 등)은 OLAP/Consumer 영역에서 처리할 예정
Closes [j007](https://github.com/jaenam615/jaebitly/issues/12)
