### PR TITLE
[J-008] Redirect 이벤트 발행을 비동기 처리로 전환

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,9 +23,9 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
 }
 
 tasks.test {
     useJUnitPlatform()
 }
-

--- a/src/main/kotlin/com/example/jaebitly/JaebitlyApplication.kt
+++ b/src/main/kotlin/com/example/jaebitly/JaebitlyApplication.kt
@@ -2,8 +2,10 @@ package com.example.jaebitly
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 
 @SpringBootApplication
+@EnableAsync
 class JaebitlyApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/example/jaebitly/infrastructure/LogRedirectEventPublisher.kt
+++ b/src/main/kotlin/com/example/jaebitly/infrastructure/LogRedirectEventPublisher.kt
@@ -1,16 +1,23 @@
 package com.example.jaebitly.infrastructure
 
 import com.example.jaebitly.application.RedirectEventPublisher
-import com.example.jaebitly.domain.ShortKey
 import com.example.jaebitly.domain.event.RedirectEvent
 import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
 @Component
 class LogRedirectEventPublisher : RedirectEventPublisher {
     private val log = LoggerFactory.getLogger(javaClass)
 
+    @Async
     override fun publish(event: RedirectEvent) {
-        log.info("redirect_event shortKey={}, occurredAt{}", event.shortKey, event.occurredAt)
+        log.info(
+            "redirect_event shortKey={}, occurredAt={}, ip={}, user-agent={}",
+            event.shortKey,
+            event.occurredAt,
+            event.ip,
+            event.userAgent,
+        )
     }
 }

--- a/src/test/kotlin/com/example/jaebitly/RedirectIntegrationTest.kt
+++ b/src/test/kotlin/com/example/jaebitly/RedirectIntegrationTest.kt
@@ -1,11 +1,15 @@
 package com.example.jaebitly
 
-import com.example.jaebitly.JaebitlyApplication
+import com.example.jaebitly.application.RedirectEventPublisher
 import com.jayway.jsonpath.JsonPath
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.timeout
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -18,35 +22,68 @@ class RedirectIntegrationTest {
     @Autowired
     lateinit var mockMvc: MockMvc
 
+    @MockBean
+    lateinit var redirectEventPublisher: RedirectEventPublisher
+
     @Test
     fun `invalid shortKey returns 404`() {
-        mockMvc.get("/invalid-key")
+        mockMvc
+            .get("/invalid-key")
             .andExpect {
                 status { isNotFound() }
             }
     }
 
     @Test
-    fun `valid shortKey redirects with 302`(){
+    fun `valid shortKey redirects with 302`() {
         // given: create link
-        val createResponse = mockMvc.post("/links"){
-            contentType = MediaType.APPLICATION_JSON
-            content = """{"originalUrl" : "https://example.com"}"""
-        }.andExpect {
-            status { isOk() }
-        }.andReturn()
-
-        println(createResponse)
-        println(createResponse.response.contentAsString)
+        val createResponse =
+            mockMvc
+                .post("/links") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"originalUrl" : "https://example.com"}"""
+                }.andExpect {
+                    status { isOk() }
+                }.andReturn()
 
         val responseBody = createResponse.response.contentAsString
         val shortKey = JsonPath.read<String>(responseBody, "$.shortKey")
 
         // when & then: redirect
-        mockMvc.get("/$shortKey")
+        mockMvc
+            .get("/$shortKey")
             .andExpect {
                 status { isFound() }
                 header { string(HttpHeaders.LOCATION, "https://example.com") }
             }
+    }
+
+    @Test
+    fun `redirect triggers event publishing async`() {
+        // given: create link
+        val createResponse =
+            mockMvc
+                .post("/links") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"originalUrl" : "https://example.com"}"""
+                }.andExpect {
+                    status { isOk() }
+                }.andReturn()
+
+        val responseBody = createResponse.response.contentAsString
+        val shortKey = JsonPath.read<String>(responseBody, "$.shortKey")
+
+        // when: redirect
+        mockMvc
+            .get("/$shortKey")
+            .andExpect {
+                status { isFound() }
+            }
+
+        //  then: event async
+        verify(
+            redirectEventPublisher,
+            timeout(1000),
+        ).publish(any())
     }
 }


### PR DESCRIPTION
## 관련 이슈
- J-008

## 작업 내용
리다이렉트 요청 처리 성능 보호를 위해
Redirect 이벤트 발행을 비동기 처리로 전환.

## 변경 사항
- RedirectEventPublisher를 @Async 기반 비동기 실행으로 변경
- 애플리케이션에 비동기 실행 설정 추가
- 리다이렉트 응답과 이벤트 발행 분리 여부 통합 테스트 추가

## 확인 사항
- [x] 리다이렉트 응답 즉시 반환 확인
- [x] 이벤트 발행 비동기 호출 검증
- [x] 기존 리다이렉트 기능 정상 동작

## 비고
이벤트 발행은 fire-and-forget 방식으로 처리되며,
실패 여부는 리다이렉트 흐름에 영향을 주지 않도록 설계.

Closes [J008](https://github.com/jaenam615/jaebitly/issues/14)