### PR TITLE
[J-010] Redirect 통계 In-Memory 적재 및 기본 집계 구조

### DIFF
--- a/src/main/kotlin/com/example/jaebitly/application/RedirectStatHandler.kt
+++ b/src/main/kotlin/com/example/jaebitly/application/RedirectStatHandler.kt
@@ -1,0 +1,7 @@
+package com.example.jaebitly.application
+
+import com.example.jaebitly.domain.event.RedirectEvent
+
+interface RedirectStatHandler {
+    fun handle(event: RedirectEvent)
+}

--- a/src/main/kotlin/com/example/jaebitly/domain/stat/RedirectStat.kt
+++ b/src/main/kotlin/com/example/jaebitly/domain/stat/RedirectStat.kt
@@ -1,0 +1,28 @@
+package com.example.jaebitly.domain.stat
+
+import com.example.jaebitly.domain.ShortKey
+import java.time.Instant
+
+data class RedirectStat(
+    val shortKey: ShortKey,
+    val lastOccurredAt: Instant,
+    val count: Long,
+) {
+    fun incrementCount(occurredAt: Instant): RedirectStat =
+        copy(
+            count = count + 1,
+            lastOccurredAt = occurredAt,
+        )
+
+    companion object {
+        fun initial(
+            shortKey: ShortKey,
+            occurredAt: Instant,
+        ): RedirectStat =
+            RedirectStat(
+                shortKey = shortKey,
+                count = 1,
+                lastOccurredAt = occurredAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/example/jaebitly/infrastructure/InMemoryRedirectStatHandler.kt
+++ b/src/main/kotlin/com/example/jaebitly/infrastructure/InMemoryRedirectStatHandler.kt
@@ -1,0 +1,31 @@
+package com.example.jaebitly.infrastructure
+
+import com.example.jaebitly.application.RedirectStatHandler
+import com.example.jaebitly.domain.ShortKey
+import com.example.jaebitly.domain.event.RedirectEvent
+import com.example.jaebitly.domain.stat.RedirectStat
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class InMemoryRedirectStatHandler : RedirectStatHandler {
+    private val stats: MutableMap<ShortKey, RedirectStat> = ConcurrentHashMap()
+
+    override fun handle(event: RedirectEvent) {
+        val key = ShortKey(event.shortKey)
+
+        stats.compute(key) { _, existing ->
+            existing?.incrementCount(event.occurredAt)
+                ?: RedirectStat.initial(
+                    shortKey = key,
+                    occurredAt = event.occurredAt,
+                )
+        }
+    }
+
+    fun getStat(shortKey: ShortKey): RedirectStat? = stats[shortKey]
+
+    fun clear() {
+        stats.clear()
+    }
+}

--- a/src/main/kotlin/com/example/jaebitly/infrastructure/LogRedirectEventConsumer.kt
+++ b/src/main/kotlin/com/example/jaebitly/infrastructure/LogRedirectEventConsumer.kt
@@ -1,15 +1,20 @@
 package com.example.jaebitly.infrastructure
 
 import com.example.jaebitly.application.RedirectEventConsumer
+import com.example.jaebitly.application.RedirectStatHandler
 import com.example.jaebitly.domain.event.RedirectEvent
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
-class LogRedirectEventConsumer : RedirectEventConsumer {
+class LogRedirectEventConsumer(
+    private val redirectStatHandler: RedirectStatHandler,
+) : RedirectEventConsumer {
     private val log = LoggerFactory.getLogger(javaClass)
 
     override fun consume(event: RedirectEvent) {
+        redirectStatHandler.handle(event)
+
         log.info(
             "redirect_event shortKey={}, occurredAt={}, ip={}, user-agent={}",
             event.shortKey,

--- a/src/test/kotlin/com/example/jaebitly/RedirectStatIntegrationTest.kt
+++ b/src/test/kotlin/com/example/jaebitly/RedirectStatIntegrationTest.kt
@@ -1,0 +1,60 @@
+package com.example.jaebitly
+
+import com.example.jaebitly.domain.ShortKey
+import com.example.jaebitly.infrastructure.InMemoryRedirectStatHandler
+import com.jayway.jsonpath.JsonPath
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RedirectStatIntegrationTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var statHandler: InMemoryRedirectStatHandler
+
+    @BeforeEach
+    fun setUp() {
+        statHandler.clear()
+    }
+
+    @Test
+    fun `redirect accumulates stats in memory`() {
+        // given: short link 생성
+        val createResponse =
+            mockMvc
+                .post("/links") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"originalUrl":"https://example.com"}"""
+                }.andReturn()
+
+        val shortKeyValue =
+            JsonPath.read<String>(createResponse.response.contentAsString, "$.shortKey")
+        val shortKey = ShortKey(shortKeyValue)
+
+        // when: redirect 요청
+        mockMvc.get("/$shortKeyValue").andReturn()
+
+        // then: 최대 1초 폴링 후 count 검증
+        val deadline = System.currentTimeMillis() + 1000
+        var count: Long? = null
+
+        while (System.currentTimeMillis() < deadline) {
+            count = statHandler.getStat(shortKey)?.count
+            if (count != null) break
+            Thread.sleep(20)
+        }
+
+        assertEquals(1L, count)
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- J-010

## 작업 내용
Redirect 이벤트를 통계 데이터로 적재하기 위한
In-Memory 기반 통계 모델과 누적 처리 구조를 추가.

## 변경 사항
- RedirectStat 도메인 모델 추가
- RedirectStatHandler 포트 정의
- InMemory 기반 통계 적재 구현
- RedirectEventConsumer에서 통계 처리 연결
- 통계 누적 동작 통합 테스트 추가

## 확인 사항
- [x] Redirect 이벤트가 통계로 누적됨
- [x] 통계 적재가 리다이렉트 응답과 분리됨
- [x] 기존 리다이렉트 기능 정상 동작

## 비고
현재 통계 저장소는 In-Memory 구현이며,
향후 Redis/OLAP 저장소로 교체를 전제로 설계됨.
Closes https://github.com/jaenam615/jaebitly/issues/18