### PR TITLE
refactor: move analytics controller under internal path

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Kotlin2JsCompilerArguments">
+    <option name="moduleKind" value="plain" />
+  </component>
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="21" />
+  </component>
+  <component name="KotlinCommonCompilerArguments">
+    <option name="apiVersion" value="1.9" />
+    <option name="languageVersion" value="1.9" />
+  </component>
   <component name="KotlinJpsPluginSettings">
     <option name="version" value="1.9.25" />
   </component>

--- a/src/main/kotlin/com/example/jaebitly/application/GetLinkAnalyticsUseCase.kt
+++ b/src/main/kotlin/com/example/jaebitly/application/GetLinkAnalyticsUseCase.kt
@@ -4,6 +4,10 @@ import com.example.jaebitly.domain.ShortKey
 import com.example.jaebitly.domain.stat.RedirectStatView
 import org.springframework.stereotype.Component
 
+/**
+ * Internal use case for redirect analytics.
+ * Used only for validating event-driven aggregation.
+ */
 @Component
 class GetLinkAnalyticsUseCase(
     private val redirectStatStore: RedirectStatStore,

--- a/src/main/kotlin/com/example/jaebitly/application/RedirectStatStore.kt
+++ b/src/main/kotlin/com/example/jaebitly/application/RedirectStatStore.kt
@@ -3,6 +3,10 @@ package com.example.jaebitly.application
 import com.example.jaebitly.domain.ShortKey
 import com.example.jaebitly.domain.stat.RedirectStat
 
+/**
+ * Internal store for redirect analytics.
+ * Implementation may change or be removed.
+ */
 interface RedirectStatStore {
     fun save(stat: RedirectStat)
 

--- a/src/main/kotlin/com/example/jaebitly/controller/internal/LinkAnalyticsController.kt
+++ b/src/main/kotlin/com/example/jaebitly/controller/internal/LinkAnalyticsController.kt
@@ -1,4 +1,4 @@
-package com.example.jaebitly.controller
+package com.example.jaebitly.controller.internal
 
 import com.example.jaebitly.application.GetLinkAnalyticsUseCase
 import org.springframework.web.bind.annotation.GetMapping
@@ -10,7 +10,11 @@ import java.time.Instant
 class LinkAnalyticsController(
     private val getLinkAnalyticsUseCase: GetLinkAnalyticsUseCase,
 ) {
-    @GetMapping("/links/{key}/analytics")
+    /**
+     * Internal analytics endpoint.
+     * Not part of public MVP.
+     */
+    @GetMapping("/internal/links/{key}/analytics")
     fun getLinkAnalytics(
         @PathVariable("key") key: String,
     ): LinkAnalyticsResponse {


### PR DESCRIPTION
## 관련 이슈
- J-012

## 작업 내용
이번 PR에서는 Redirect analytics 기능을 MVP 외부의 internal feature로 명확히 구분하는 정리 작업을 수행했습니다.
기능 확장 없이, 경로/구조/의도를 드러내는 최소한의 변경만 포함합니다.

## 변경 사항
- Analytics controller를 internal 성격이 드러나는 위치로 이동
- Analytics endpoint를 `/internal/**` 하위 경로로 변경
- Analytics 관련 UseCase / Store에 internal feature임을 명시하는 주석(KDoc) 추가
- README에 Analytics가 internal feature이며 MVP 범위가 아님을 명시

## 확인 사항
- [x] 로컬에서 정상 실행 확인
- [x] Redirect / ShortLink MVP API 정상 동작 확인
- [x] Analytics endpoint가 `/internal/**` 경로로만 접근 가능한지 확인
- [x] 기능 추가 없이 정리 작업만 포함되었는지 확인

## 비고
- Analytics는 이벤트 기반 설계 및 집계 전략 검증을 위한 내부 실험용 기능입니다.
- 본 PR은 기능 추가가 아닌, MVP 경계 명확화를 위한 정리 PR입니다.
- 향후 성능/저장소/조회 확장은 별도 티켓에서 진행할 예정입니다.

Closes https://github.com/jaenam615/jaebitly/issues/22